### PR TITLE
Pcr14 computation logic and tests

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -61,6 +61,12 @@ enum Command {
             help = "Compute PCRs as if secure boot was disabled in the system"
         )]
         no_secureboot: bool,
+        #[arg(
+            long = "mok-variables",
+            required = true,
+            help = "Path to directory storing MokListRT, MokListTrustedRT and MokListXRT"
+        )]
+        mok_variables: String,
     },
     /// Compute PCR 4
     Pcr4 {
@@ -114,6 +120,15 @@ enum Command {
         /// Path to a UKI
         uki: String,
     },
+    /// Compute PCR 14
+    Pcr14 {
+        #[arg(
+            long = "mok-variables",
+            required = true,
+            help = "Path to directory storing MokListRT, MokListTrustedRT and MokListXRT"
+        )]
+        mok_variables: String,
+    },
 }
 
 #[derive(Serialize, Deserialize)]
@@ -143,11 +158,13 @@ fn main() -> Result<()> {
             secureboot_variables,
             uki,
             no_secureboot,
+            mok_variables,
         } => {
             let pcrs = vec![
                 compute_pcr4(kernels, esp, *uki, !no_secureboot),
                 compute_pcr7(secureboot_variables.efivars.as_deref(), esp, !no_secureboot),
                 /* compute_pcr11(), */
+                compute_pcr14(mok_variables),
             ];
             println!(
                 "{}",
@@ -176,6 +193,11 @@ fn main() -> Result<()> {
         }
         Command::Pcr11 { uki } => {
             let pcr = compute_pcr11(uki);
+            println!("{}", serde_json::to_string_pretty(&pcr).unwrap());
+            Ok(())
+        }
+        Command::Pcr14 { mok_variables } => {
+            let pcr = compute_pcr14(mok_variables);
             println!("{}", serde_json::to_string_pretty(&pcr).unwrap());
             Ok(())
         }

--- a/justfile
+++ b/justfile
@@ -10,8 +10,10 @@ test-container: prepare-test-env get-reference-values
         -v $PWD/target/debug/:/var/srv \
         -v $PWD/test-data/:/var/srv/test-data \
         {{image}} \
-        /var/srv/compute-pcrs all --efivars /var/srv/test-data/efivars/qemu-ovmf/fcos-42 \
-        > test/result.json 2>/dev/null
+        /var/srv/compute-pcrs all \
+            --efivars /var/srv/test-data/efivars/qemu-ovmf/fcos-42 \
+            --mok-variables /var/srv/test-data/mok-variables/fcos-42 \
+            > test/result.json 2>/dev/null
     diff test-fixtures/quay.io_fedora_fedora-coreos_42.20250705.3.0/all-pcrs.json test/result.json || (echo "FAILED" && exit 1)
     echo "OK"
 
@@ -86,4 +88,13 @@ test-secureboot-disabled: prepare-test-env-local
         --secureboot-disabled \
         > test/result.json 2>/dev/null
     diff test-fixtures/quay.io_fedora_fedora-coreos_42.20250705.3.0/pcr7-sb-disabled.json test/result.json || (echo "FAILED" && exit 1)
+    echo "OK"
+
+test-default-mok-keys-fcos42: prepare-test-env-local
+    #!/bin/bash
+    set -euo pipefail
+    cargo run -- pcr14 \
+        --mok-variables test-data/mok-variables/fcos-42 \
+        > test/result.json 2>/dev/null
+    diff test-fixtures/quay.io_fedora_fedora-coreos_42.20250705.3.0/pcr14.json test/result.json || (echo "FAILED" && exit 1)
     echo "OK"

--- a/lib/src/mok.rs
+++ b/lib/src/mok.rs
@@ -1,0 +1,40 @@
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const MOK_EVENTS_PCR14: [&str; 3] = ["MokList", "MokListX", "MokListTrusted"];
+
+fn mok_event_to_file_name(event_name: &str) -> String {
+    format!("{}RT", event_name)
+}
+
+fn mok_event_hash(events_dir_path: &Path, event_name: &str) -> Vec<u8> {
+    let data = fs::read(events_dir_path.join(mok_event_to_file_name(event_name))).unwrap();
+    Sha256::digest(data).to_vec()
+}
+
+#[derive(Debug, Clone)]
+pub struct MokEventHashes {
+    /// Path to the directory containing MokList{}RT files
+    path: PathBuf,
+    index: usize,
+}
+
+impl MokEventHashes {
+    pub fn new(path: &str) -> MokEventHashes {
+        MokEventHashes {
+            path: path.into(),
+            index: 0,
+        }
+    }
+}
+
+impl Iterator for MokEventHashes {
+    type Item = Vec<u8>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let hash = mok_event_hash(&self.path, MOK_EVENTS_PCR14.get(self.index)?);
+        self.index += 1;
+        Some(hash)
+    }
+}

--- a/test-fixtures/quay.io_fedora_fedora-coreos_42.20250705.3.0/all-pcrs.json
+++ b/test-fixtures/quay.io_fedora_fedora-coreos_42.20250705.3.0/all-pcrs.json
@@ -67,6 +67,24 @@
           "hash": "ad5901fd581e6640c742c488083b9ac2c48255bd28a16c106c6f9df52702ee3f"
         }
       ]
+    },
+    {
+      "id": 14,
+      "value": "17cdefd9548f4383b67a37a901673bf3c8ded6f619d36c8007562de1d93c81cc",
+      "parts": [
+        {
+          "name": "EV_IPL",
+          "hash": "e8e48e3ad10bc243341b4663c0057aef0ec7894ccc9ecb0598f0830fa57f7220"
+        },
+        {
+          "name": "EV_IPL",
+          "hash": "8d8a3aae50d5d25838c95c034aadce7b548c9a952eb7925e366eda537c59c3b0"
+        },
+        {
+          "name": "EV_IPL",
+          "hash": "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a"
+        }
+      ]
     }
   ]
 }

--- a/test-fixtures/quay.io_fedora_fedora-coreos_42.20250705.3.0/pcr14.json
+++ b/test-fixtures/quay.io_fedora_fedora-coreos_42.20250705.3.0/pcr14.json
@@ -1,0 +1,18 @@
+{
+  "id": 14,
+  "value": "17cdefd9548f4383b67a37a901673bf3c8ded6f619d36c8007562de1d93c81cc",
+  "parts": [
+    {
+      "name": "EV_IPL",
+      "hash": "e8e48e3ad10bc243341b4663c0057aef0ec7894ccc9ecb0598f0830fa57f7220"
+    },
+    {
+      "name": "EV_IPL",
+      "hash": "8d8a3aae50d5d25838c95c034aadce7b548c9a952eb7925e366eda537c59c3b0"
+    },
+    {
+      "name": "EV_IPL",
+      "hash": "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a"
+    }
+  ]
+}


### PR DESCRIPTION
~It is built on top of https://github.com/confidential-clusters/compute-pcrs/pull/7~

~Wait until it is fixed and merged.~

This adds the basic/default logic to compute pcr14 values.