### PR TITLE
certs: Parse emailAddress object

### DIFF
--- a/lib/src/certs.rs
+++ b/lib/src/certs.rs
@@ -60,6 +60,8 @@ fn entry_to_string(entry: &openssl::x509::X509NameEntryRef) -> Option<String> {
         return Some(format!("CN={data_str}"));
     } else if object == "organizationalUnitName" {
         return Some(format!("OU={data_str}"));
+    } else if object == "emailAddress" {
+        return Some(format!("emailAddress={data_str}"));
     }
     None
 }


### PR DESCRIPTION
Some certs also carry the emailAddress object, which was not being parsed. That lead into some cert comparison errors.

A proper cert comparison algorithm would overcome this issue, but let's stick to the currently implemented logic for now.

This commit makes the subject/issuer string generator also account for emailAddress cert objects.