### PR TITLE
pefile: Fix cargo warnings

### DIFF
--- a/lib/src/pefile.rs
+++ b/lib/src/pefile.rs
@@ -117,7 +117,7 @@ impl PeFile {
         vec![]
     }
 
-    pub fn signatures(&self) -> lief::pe::signature::Signatures {
+    pub fn signatures(&self) -> lief::pe::signature::Signatures<'_> {
         self.image.signatures()
     }
 


### PR DESCRIPTION
cargo would complain:

  > the same lifetime is referred to in inconsistent ways, making the
  > signature confusing

This commit makes cargo happy.