### PR TITLE
WIP: justfile: Support running test-container against other container images

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,10 +1,13 @@
 image := "quay.io/fedora/fedora-coreos:42.20250705.3.0"
 
-test-container: prepare-test-env get-reference-values
+build:
     #!/bin/bash
     set -euo pipefail
-    # set -x
     cargo build
+
+test-container: prepare-test-env get-reference-values build
+    #!/bin/bash
+    set -euo pipefail
     podman run --rm \
         --security-opt label=disable \
         -v $PWD/target/debug/:/var/srv \

--- a/justfile
+++ b/justfile
@@ -12,8 +12,11 @@ test-container: prepare-test-env get-reference-values build
         --security-opt label=disable \
         -v $PWD/target/debug/:/var/srv \
         -v $PWD/test-data/:/var/srv/test-data \
-        {{image}} \
+        --mount=type=image,source={{image}},destination=/var/srv/image,rw=false \
+        fedora:latest \
         /var/srv/compute-pcrs all \
+            --kernels /var/srv/image/usr/lib/modules \
+            --esp /var/srv/image/usr/lib/bootupd/updates \
             --efivars /var/srv/test-data/efivars/qemu-ovmf/fcos-42 \
             --mok-variables /var/srv/test-data/mok-variables/fcos-42 \
             > test/result.json 2>/dev/null


### PR DESCRIPTION
{{image}}=FCOS would work, but compute-pcrs would struggle to run properly on other container images.

This patch series is supposed to add some changes to the justfile to support running `test-container` against container images other than just fcos42.

Right now, it does so by running compute-pcrs on a fedora container image, to which the target fcos/rhcos/... container will be mounted.

But it's just WIP yet.

cc: @Jakob-Naucke as I came across this after discussing how he was planning to use `compute-pcrs` from the operator's perspective.