### PR TITLE
cli: Remove misleading helpdoc

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -36,7 +36,7 @@ struct SecureBootVarStores {
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    /// Compute all possible PCR values from the binaries available in the current environment. Meant to be run inside a Bootable Container.
+    /// Compute all possible PCR values from the binaries available in the current environment
     All {
         #[arg(
             long,


### PR DESCRIPTION
It does not need to be run from a bootable container. As long as it can reach the files containing the target system's vmlinuz, shim/grub and other reference values (sb efivars and mok variables), it is okay.

cc: @Jakob-Naucke 