### PR TITLE
combine: Multiple events per event ID

### DIFF
--- a/lib/src/tpmevents/combine.rs
+++ b/lib/src/tpmevents/combine.rs
@@ -77,7 +77,7 @@ mod tests;
 #[derive(Clone, Debug)]
 pub struct EventCombinationError {}
 
-pub type EventNode = tree::ResultNode<TPMEvent, EventCombinationError>;
+pub type EventNode = tree::ResultNode<Vec<TPMEvent>, EventCombinationError>;
 
 pub fn combine_images(images: &[Vec<TPMEvent>]) -> Vec<Vec<Pcr>> {
     if images.len() == 1 {
@@ -101,7 +101,7 @@ pub fn combine(this: &[TPMEvent], that: &[TPMEvent]) -> Vec<Vec<Pcr>> {
         Some(st) => st
             .iter()
             .flat_map(|t| t.valid_branches())
-            .map(|e| compile_pcrs(&e))
+            .map(|e| compile_pcrs(&e.into_iter().flatten().collect::<Vec<_>>()))
             .collect(),
         None => vec![],
     }
@@ -109,8 +109,8 @@ pub fn combine(this: &[TPMEvent], that: &[TPMEvent]) -> Vec<Vec<Pcr>> {
 
 fn event_subtree(
     event_id: &TPMEventID,
-    map_this: &HashMap<TPMEventID, TPMEvent>,
-    map_that: &HashMap<TPMEventID, TPMEvent>,
+    map_this: &HashMap<TPMEventID, Vec<TPMEvent>>,
+    map_that: &HashMap<TPMEventID, Vec<TPMEvent>>,
     group_this: u32,
     group_that: u32,
 ) -> Option<Vec<EventNode>> {
@@ -119,7 +119,7 @@ fn event_subtree(
     let opt_this = map_this.get(event_id);
     let opt_that = map_that.get(event_id);
     // Divergences contains tuples with events, and this/that masked groups
-    let mut divs: Vec<(&TPMEvent, u32, u32)> = vec![];
+    let mut divs: Vec<(&Vec<TPMEvent>, u32, u32)> = vec![];
     let mut nodes: Vec<EventNode> = vec![];
     let mut event_required = false;
     let event_groups = event_id.groups();
@@ -182,8 +182,8 @@ fn event_subtree(
         }
     }
 
-    for (event, g_this, g_that) in divs {
-        let mut node = EventNode::new_ok(event.clone());
+    for (events, g_this, g_that) in divs {
+        let mut node = EventNode::new_ok(events.clone());
         if let Some(children) = event_subtree(&event_id.next()?, map_this, map_that, g_this, g_that)
         {
             for c in children {
@@ -196,6 +196,14 @@ fn event_subtree(
     Some(nodes)
 }
 
-fn tpm_event_id_hashmap(events: &[TPMEvent]) -> HashMap<TPMEventID, TPMEvent> {
-    events.iter().map(|e| (e.id.clone(), e.clone())).collect()
+fn tpm_event_id_hashmap(events: &[TPMEvent]) -> HashMap<TPMEventID, Vec<TPMEvent>> {
+    let mut lookup = HashMap::<TPMEventID, Vec<TPMEvent>>::new();
+    for event in events {
+        lookup
+            .entry(event.id.clone())
+            .or_default()
+            .push(event.clone());
+    }
+
+    lookup
 }

--- a/lib/src/tpmevents/combine/tests.rs
+++ b/lib/src/tpmevents/combine/tests.rs
@@ -30,15 +30,21 @@ fn test_tpm_event_id_hashmap() {
         hash: vec![1, 2, 3, 4, 5],
         id: TPMEventID::Pcr11UnameContent,
     };
-    let events = vec![foo.clone(), bar.clone(), foobar.clone()];
+    let foobaz = TPMEvent {
+        name: "FOOBAR".into(),
+        pcr: 0xe8,
+        hash: vec![6, 7, 8, 9, 10],
+        id: TPMEventID::Pcr11UnameContent,
+    };
+    let events = vec![foo.clone(), bar.clone(), foobar.clone(), foobaz.clone()];
 
     let res = tpm_event_id_hashmap(&events);
     assert_eq!(
         res,
         HashMap::from([
-            (TPMEventID::PcrRootNodeEvent, foo),
-            (TPMEventID::Pcr11Sbat, bar),
-            (TPMEventID::Pcr11UnameContent, foobar),
+            (TPMEventID::PcrRootNodeEvent, vec![foo]),
+            (TPMEventID::Pcr11Sbat, vec![bar]),
+            (TPMEventID::Pcr11UnameContent, vec![foobar, foobaz]),
         ])
     );
 }
@@ -1680,5 +1686,60 @@ fn test_all_pcrs_2_images() {
                 "17cdefd9548f4383b67a37a901673bf3c8ded6f619d36c8007562de1d93c81cc"
             ],
         ]
+    );
+}
+
+#[test]
+fn test_combine_multiple_events_same_id() {
+    let this = vec![
+        TPMEvent {
+            pcr: 4,
+            name: "EV_EFI_ACTION".to_string(),
+            hash: hex::decode("0000000000000000000000000000000000000000000000000000000000000000")
+                .unwrap(),
+            id: TPMEventID::Pcr4EfiCall,
+        },
+        TPMEvent {
+            pcr: 4,
+            name: "EV_EFI_ACTION".to_string(),
+            hash: hex::decode("1111111111111111111111111111111111111111111111111111111111111111")
+                .unwrap(),
+            id: TPMEventID::Pcr4EfiCall,
+        },
+    ];
+    let that = vec![
+        TPMEvent {
+            pcr: 4,
+            name: "EV_EFI_ACTION".to_string(),
+            hash: hex::decode("2222222222222222222222222222222222222222222222222222222222222222")
+                .unwrap(),
+            id: TPMEventID::Pcr4EfiCall,
+        },
+        TPMEvent {
+            pcr: 4,
+            name: "EV_EFI_ACTION".to_string(),
+            hash: hex::decode("3333333333333333333333333333333333333333333333333333333333333333")
+                .unwrap(),
+            id: TPMEventID::Pcr4EfiCall,
+        },
+    ];
+    let foobar = vec![this, that];
+
+    let res = combine_images(&foobar);
+    let pcr_values: Vec<Vec<String>> = res
+        .iter()
+        .map(|i| {
+            i.iter()
+                .map(|p| hex::encode(p.value.clone()))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    assert_eq!(
+        pcr_values,
+        vec![
+            vec!["4cb4c04374037e0ddde15a714a4295501e2cbc3b0971e4c3eebce23ef433dc4d",],
+            vec!["22d0d408147e904fa9fe6feba5fc51374e44f07101e208e62fd5453841595ade",],
+        ],
     );
 }


### PR DESCRIPTION
It was assumed that each TPMEventID would hold only 1 event at a time. Now that other PCR predictions and support for UKI are on the table, that does not happened to longer be true.

This commit only updates internal plumbing. Pretty much the logic in tpmevents/combine so as to be able to process a list of TPMEvents per each kind of TPMEventID.

It's now assumed that TPMEvents of a given TPMEventID move in block. In other words, that they can't be combined with TPMEvents from the other images independently. It's all TPMEvents of TPMEvent ID X from image A or from image B. It can't be TPMEvent 1 from image A and TPMEvent 2 from image B.

Fixes https://github.com/trusted-execution-clusters/compute-pcrs/issues/76.
Affects: https://github.com/trusted-execution-clusters/compute-pcrs/pull/33, https://github.com/trusted-execution-clusters/compute-pcrs/pull/75